### PR TITLE
Clean up README wording and unused import

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm i
 npm run start
 ```
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens a browser window. Most changes are reflected live without having to restart the server.
 
 ## PRs
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState, } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';


### PR DESCRIPTION
## Summary
- Remove an unused React import from the home page
- Fix a README sentence describing the local dev server

## Verification
- `npm ci`
- `npm run build`